### PR TITLE
Current path getter

### DIFF
--- a/dataforest/core/DataBranch.py
+++ b/dataforest/core/DataBranch.py
@@ -276,6 +276,13 @@ class DataBranch:
             self._process_runs[process_name] = ProcessRun(self, process_name, process)
         return self._process_runs[process_name]
 
+    @property
+    def current_path(self) -> str:
+        """
+        The paths at current `process_run`
+        """
+        return self._paths[self._current_process]
+
     @staticmethod
     def _combine_datasets(
         root_dir: Union[str, Path],

--- a/dataforest/core/Spec.py
+++ b/dataforest/core/Spec.py
@@ -41,7 +41,7 @@ class Spec(list):
         >>>         "alias": "linear_dim_reduce",
         >>>         "params": {
         >>>             "algorithm": "pca",
-        >>>             "n_pcs": 30,
+        >>>             "pca_npcs": 30,
         >>>         }
         >>>     },
         >>>     {

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,0 +1,17 @@
+### Updates
+- 
+
+### Testing
+[ ] Tested locally
+[ ] Tested notebook
+[ ] Cleared notebook outputs
+[ ] Docstrings and type-hinting
+
+### Fixes
+- 
+
+### Future works
+- 
+
+### Reviewer's tasks
+- 


### PR DESCRIPTION
### Updates
- Main changes in: https://github.com/TheAustinator/cellforest/pull/10
- Getter for path at current ProcessRun (not yet used in R loaders)
- `Spec.py` small change to match current spec

### Testing
[x] Tested locally
~~[ ] Tested notebook~~
~~[ ] Cleared notebook outputs~~
~~[ ] Docstrings and type-hinting~~

### Fixes
- None

### Future works
- None

### Reviewer's tasks
- Nothing absurd?